### PR TITLE
Cleaned up package.json for ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,25 +28,32 @@
     "ts-node": "10.9.1",
     "typescript": "4.9.4"
   },
-  "exports": "./dist/lib/index.js",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=16.0.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/lib/index.js",
+      "require": "./dist-cjs/lib/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "homepage": "TODO",
   "keywords": [
     "TODO"
   ],
   "license": "UNLICENSED",
+  "main": "./dist-cjs/lib/index.js",
   "name": "@snowcoders/scaffold-typescript-cli--circleci",
-  "repository": "TODO",
   "private": "true",
+  "repository": "TODO",
   "scripts": {
     "build": "concurrently \"npm:build:*\"",
     "build:cjs": "tsc -p tsconfig.cjs.json && cpy ./src/cjs-package.json.txt ./dist-cjs --flat --rename=package.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "clean": "rimraf coverage dist dist-cjs",
-    "husky:pre-commit": "echo 'TODO'",
     "husky:commit-msg": "echo 'TODO'",
+    "husky:pre-commit": "echo 'TODO'",
     "husky:pre-push": "echo 'TODO'",
     "prepare": "npm run clean && npm run build && npx --no husky install",
     "start": "node bin/index.js",


### PR DESCRIPTION
- Dropped 12 and 14 support
- Fixed exports to reference both import and require
- Added main as cjs packages still expect that